### PR TITLE
Improved pyproject.toml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,9 +17,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run:
-        python -m pip install pytest numpy
+    - name: Install package and test dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+        python -m pip install .
     - name: Test with pytest
       run:
         pytest -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: python
-python:
-  - "3.6"
-script: pytest

--- a/grader/__init__.py
+++ b/grader/__init__.py
@@ -1,39 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 grader: a Python module and command-line utility to grade applications.
 """
-import os
 
-# current dir
-CWD = os.path.abspath(os.path.dirname(__file__))
+__version__ = '0.1'
 
-__name__ =        'grader'
-__description__ = 'a Python module and command-line utility to grade applications'
-__version__ =     '0.1'
-__url__ =         'https://github.com/ASPP/grader'
-__author__ =      'grader contributor'
-__license__ =     'GPLv3+'
-
-
-def revision():
-    # get the git SHA if we are in a git repo (only useful for devs)
-    import subprocess
-
-    # try two options for getting the git revision
-    # - nice version with tags
-    # - plain SHA
-    for cmd in ('git describe --tags --dirty=+'), ('git rev-parse HEAD'):
-        try:
-            proc = subprocess.check_output(cmd.split(), cwd=CWD,
-                    stderr=subprocess.PIPE, universal_newlines=True)
-            revision = proc.strip()
-        except Exception:
-            # ok, don't bother
-            revision = ''
-    return revision
-
-
-# have a way to test from python
-def test():
-    import pytest
-    pytest.main([CWD,])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,12 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.version]
+path = "grader/__init__.py"
+
 [project]
 name = "grader"
 description = "a Python module and command-line utility to grade applications"
-version = "0.1"
 authors = [{name = "Grader contributors"}]
 keywords = ["grading applications"]
 license = "GPL-3.0-or-later"
@@ -17,6 +19,7 @@ classifiers = [ 'Development Status :: 3 - Alpha',
 urls = {Homepage = "https://github.com/ASPP/grader"}
 requires-python = ">= 3.10"
 dependencies = ['numpy',]
+dynamic = ["version",]
 
 [project.readme]
 file = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "grader"
 description = "a Python module and command-line utility to grade applications"
@@ -23,3 +27,8 @@ grader = "grader.grader:main"
 
 [tool.aliases]
 test = "pytest"
+
+[dependency-groups]
+dev = [
+    "pytest",
+]


### PR DESCRIPTION
Entry scripts need a build system to properly work, so I added hatchling. This allows us also to take the version from `grader/__init__.py`. I also removed the git revision stuff; not sure if this is really needed anymore.

Also added a dev dependency group so now grader+pytest works with `uv` without any manual venv:

    git clone https://github.com/ASPP/grader
    cd grader/

    uv run pytest
    uv run grader tests/data/year99/applications.csv
